### PR TITLE
Use `cargo`'s shrink settings

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -7,19 +7,19 @@ REM
 
 REM Enable Link Time Optimization (LTO) for our release builds. This increases link time but drastically reduces
 REM binary size.
-set CARGO_PROFILE_RELEASE_LTO='true'
+set CARGO_PROFILE_RELEASE_LTO=true
 
 REM Use a single code gen unit, this effectively disables parallel linking but ensures that everything is linked
 REM together in a single unit which reduces the file-size at the cost of link time.
 REM Default for a release build is 16
-set CARGO_PROFILE_RELEASE_CODEGEN_UNITS='1'
+set CARGO_PROFILE_RELEASE_CODEGEN_UNITS=1
 
 REM Strip the binaries. This reduces the filesize of the final release.
-set CARGO_PROFILE_RELEASE_STRIP='symbols'
+set CARGO_PROFILE_RELEASE_STRIP=symbols
 
 REM Optimize the binary for size. This reduces the filesize at the cost of a slower binary.
 REM Options are 's' (size), 'z' (size and speed), '0-3' (speed, 0 being no optimization, 3 being max optimization)
-set CARGO_PROFILE_OPT_LEVEL='s'
+set CARGO_PROFILE_OPT_LEVEL=s
 
 
 set CARGO_HOME=D:\cargo

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,3 +1,27 @@
+REM Copy from pixi GitHub rust build ci job
+REM
+REM These are some environment variables that configure the build so that the binary size is reduced.
+REM Inspiration was taken from this blog: https://arusahni.net/blog/2020/03/optimizing-rust-binary-size.html
+REM They're only enable it on main and releases.
+REM
+
+REM Enable Link Time Optimization (LTO) for our release builds. This increases link time but drastically reduces
+REM binary size.
+set CARGO_PROFILE_RELEASE_LTO='true'
+
+REM Use a single code gen unit, this effectively disables parallel linking but ensures that everything is linked
+REM together in a single unit which reduces the file-size at the cost of link time.
+REM Default for a release build is 16
+set CARGO_PROFILE_RELEASE_CODEGEN_UNITS='1'
+
+REM Strip the binaries. This reduces the filesize of the final release.
+set CARGO_PROFILE_RELEASE_STRIP='symbols'
+
+REM Optimize the binary for size. This reduces the filesize at the cost of a slower binary.
+REM Options are 's' (size), 'z' (size and speed), '0-3' (speed, 0 being no optimization, 3 being max optimization)
+set CARGO_PROFILE_OPT_LEVEL='s'
+
+
 set CARGO_HOME=D:\cargo
 cargo install --locked --bins --root %PREFIX% --path .
 if %errorlevel% NEQ 0 exit /b %errorlevel%

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,6 +1,30 @@
 #!/usr/bin/env bash
 
 export OPENSSL_DIR=$PREFIX
+
+# Copy from pixi GitHub rust build ci job
+#
+# These are some environment variables that configure the build so that the binary size is reduced.
+# Inspiration was taken from this blog: https://arusahni.net/blog/2020/03/optimizing-rust-binary-size.html
+# They're only enable it on main and releases.
+#
+
+# Enable Link Time Optimization (LTO) for our release builds. This increases link time but drastically reduces
+# binary size.
+export CARGO_PROFILE_RELEASE_LTO='true'
+
+# Use a single code gen unit, this effectively disables parallel linking but ensures that everything is linked
+# together in a single unit which reduces the file-size at the cost of link time.
+# Default for a release build is 16
+export CARGO_PROFILE_RELEASE_CODEGEN_UNITS='1'
+
+# Strip the binaries. This reduces the filesize of the final release.
+export CARGO_PROFILE_RELEASE_STRIP='symbols'
+
+# Optimize the binary for size. This reduces the filesize at the cost of a slower binary.
+# Options are 's' (size), 'z' (size and speed), '0-3' (speed, 0 being no optimization, 3 being max optimization)
+export CARGO_PROFILE_OPT_LEVEL='s'
+
 cargo install --locked --bins --root ${PREFIX} --path .
 cargo-bundle-licenses --format yaml --output ${SRC_DIR}/THIRDPARTY.yml
 rm $PREFIX/.crates2.json

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -23,7 +23,7 @@ export CARGO_PROFILE_RELEASE_STRIP='symbols'
 
 # Optimize the binary for size. This reduces the filesize at the cost of a slower binary.
 # Options are 's' (size), 'z' (size and speed), '0-3' (speed, 0 being no optimization, 3 being max optimization)
-export CARGO_PROFILE_OPT_LEVEL='s'
+export CARGO_PROFILE_OPT_LEVEL='z'
 
 cargo install --locked --bins --root ${PREFIX} --path .
 cargo-bundle-licenses --format yaml --output ${SRC_DIR}/THIRDPARTY.yml

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 57e4c9746e3d392623a02ac918c02e90f1af7e6356add4d22d5bde196712adc3
 
 build:
-  number: 0
+  number: 1
   # disable binary prefix detection, because rattler-build encodes the old `anaconda1anaconda2anaconda3` prefix
   # somewhere to make old packages installable. In other words, conda-build finds a false-positive here.
   detect_binary_files_with_prefix: false


### PR DESCRIPTION
This was sparked by a ping from https://github.com/bollwyvl in #46

I think I already fixed it in pixi main with this PR: https://github.com/prefix-dev/pixi/pull/1477

But for good measure I also add the settings we use in the main repo's github actions build to streamline the two builds even more. 

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Ensured the license file is being packaged.

