### PR TITLE
Fix/jemalloc issue

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -17,7 +17,6 @@ rattler-build = "*"
 
 [tasks]
 inspect-all = "inspect_artifacts --all-packages"
-build = "rattler-build build --recipe recipe"
 "build-linux_64_" = "rattler-build build --recipe recipe -m .ci_support/linux_64_.yaml"
 "inspect-linux_64_" = "inspect_artifacts --recipe-dir recipe -m .ci_support/linux_64_.yaml"
 "build-linux_aarch64_" = "rattler-build build --recipe recipe -m .ci_support/linux_aarch64_.yaml"

--- a/recipe/build.bat
+++ b/recipe/build.bat
@@ -1,9 +1,0 @@
-set CARGO_HOME=D:\cargo
-cargo install --locked --bins --root %PREFIX% --path .
-if %errorlevel% NEQ 0 exit /b %errorlevel%
-cargo-bundle-licenses --format yaml --output %SRC_DIR%/THIRDPARTY.yml
-if %errorlevel% NEQ 0 exit /b %errorlevel%
-del %PREFIX%\.crates2.json
-if %errorlevel% NEQ 0 exit /b %errorlevel%
-del %PREFIX%\.crates.toml
-if %errorlevel% NEQ 0 exit /b %errorlevel%

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-
+# If the linux-aarch64 and linux-ppc64le targets are present, set JEMALLOC_SYS_WITH_LG_PAGE to 16
 export OPENSSL_DIR=$PREFIX
 cargo install --locked --bins --root ${PREFIX} --path .
 cargo-bundle-licenses --format yaml --output ${SRC_DIR}/THIRDPARTY.yml

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,7 +1,0 @@
-#!/usr/bin/env bash
-# If the linux-aarch64 and linux-ppc64le targets are present, set JEMALLOC_SYS_WITH_LG_PAGE to 16
-export OPENSSL_DIR=$PREFIX
-cargo install --locked --bins --root ${PREFIX} --path .
-cargo-bundle-licenses --format yaml --output ${SRC_DIR}/THIRDPARTY.yml
-rm $PREFIX/.crates2.json
-rm $PREFIX/.crates.toml

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -13,18 +13,17 @@ source:
   sha256: b7cff3f4dd3a1e164f1088d07fe4d20b5830855d481b0811d979074ab0d3bc08
 
 build:
-  number: 0
+  number: 1
 
   script:
     env:
-      JEMALLOC_SYS_WITH_LG_PAGE: ${{ 16 if target_platform == "linux-aarch64" else 0 }}
+      JEMALLOC_SYS_WITH_LG_PAGE: ${{ "16" if target_platform == "linux-aarch64" or target_platform == "linux-ppc64le" }}
       OPENSSL_DIR: ${{ prefix }}
     interpreter: nu
     content: |
-        cargo install --locked --bins --root ${PREFIX} --path .
-        cargo-bundle-licenses --format yaml --output ${SRC_DIR}/THIRDPARTY.yml
-        rm $PREFIX/.crates2.json
-        rm $PREFIX/.crates.toml
+        echo $env.JEMALLOC_SYS_WITH_LG_PAGE
+        cargo install --locked --bins --root $env.PREFIX --path . --no-track
+        cargo-bundle-licenses --format yaml --output $"($env.SRC_DIR)/THIRDPARTY.yml"
 
 
 

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -17,6 +17,7 @@ build:
 
   script:
     env:
+      # This env var  specifies the base 2 log of the allocator page size
       JEMALLOC_SYS_WITH_LG_PAGE: ${{ "16" if target_platform == "linux-aarch64" or target_platform == "linux-ppc64le" }}
       OPENSSL_DIR: ${{ prefix }}
     interpreter: nu

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -21,7 +21,7 @@ build:
       OPENSSL_DIR: ${{ prefix }}
     interpreter: nu
     content: |
-        echo $env.JEMALLOC_SYS_WITH_LG_PAGE
+        echo test $env.JEMALLOC_SYS_WITH_LG_PAGE
         cargo install --locked --bins --root $env.PREFIX --path . --no-track
         cargo-bundle-licenses --format yaml --output $"($env.SRC_DIR)/THIRDPARTY.yml"
 

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -21,7 +21,6 @@ build:
       OPENSSL_DIR: ${{ prefix }}
     interpreter: nu
     content: |
-        echo test $env.JEMALLOC_SYS_WITH_LG_PAGE
         cargo install --locked --bins --root $env.PREFIX --path . --no-track
         cargo-bundle-licenses --format yaml --output $"($env.SRC_DIR)/THIRDPARTY.yml"
 

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -19,8 +19,22 @@ build:
   prefix_detection:
     ignore_binary_files: false
 
+  script:
+    env:
+      JEMALLOC_SYS_WITH_LG_PAGE: ${{ 16 if target_platform == "linux-aarch64" else 0 }}
+      OPENSSL_DIR: ${{ prefix }}
+    interpreter: nu
+    content: |
+        cargo install --locked --bins --root ${PREFIX} --path .
+        cargo-bundle-licenses --format yaml --output ${SRC_DIR}/THIRDPARTY.yml
+        rm $PREFIX/.crates2.json
+        rm $PREFIX/.crates.toml
+
+
+
 requirements:
   build:
+    - nushell
     - ${{ compiler('rust') }}
     - cargo-bundle-licenses
     # to compile the libsolv parts

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -78,3 +78,4 @@ extra:
     - baszalmstra
     - tdejager
     - ruben-arts
+    - Hofer-Julian


### PR DESCRIPTION
Related pixi issue: https://github.com/prefix-dev/pixi/pull/2937

While `nushell` is still not mainstream. I would like to use it in pixi-feedstock already as the script is very straight forward. 

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

