### PR TITLE
Add win-arm64 support; build with native-tls

### DIFF
--- a/.azure-pipelines/azure-pipelines-win.yml
+++ b/.azure-pipelines/azure-pipelines-win.yml
@@ -14,6 +14,12 @@ jobs:
         build_workspace_dir: D:\\bld\\
         store_build_artifacts: false
         tools_install_dir: D:\Miniforge
+      win_arm64_:
+        CONFIG: win_arm64_
+        UPLOAD_PACKAGES: 'True'
+        build_workspace_dir: C:\\bld\\
+        store_build_artifacts: false
+        tools_install_dir: C:\Miniforge
   timeoutInMinutes: 360
   variables:
     UPLOAD_TEMP: D:\\tmp

--- a/.ci_support/win_64_.yaml
+++ b/.ci_support/win_64_.yaml
@@ -8,8 +8,6 @@ channel_targets:
 - conda-forge main
 cxx_compiler:
 - vs2022
-libgit2:
-- '1.9'
 rust_compiler:
 - rust
 target_platform:

--- a/.ci_support/win_arm64_.yaml
+++ b/.ci_support/win_arm64_.yaml
@@ -1,0 +1,16 @@
+c_compiler:
+- vs2022
+c_stdlib:
+- vs
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- vs2022
+libgit2:
+- '1.9'
+rust_compiler:
+- rust
+target_platform:
+- win-arm64

--- a/.ci_support/win_arm64_.yaml
+++ b/.ci_support/win_arm64_.yaml
@@ -8,8 +8,6 @@ channel_targets:
 - conda-forge main
 cxx_compiler:
 - vs2022
-libgit2:
-- '1.9'
 rust_compiler:
 - rust
 target_platform:

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -1,5 +1,6 @@
 build_platform:
   osx_64: osx_arm64
+  win_arm64: win_64
 provider:
   osx_arm64: default
   linux_aarch64: default

--- a/pixi.toml
+++ b/pixi.toml
@@ -53,6 +53,12 @@ description = "Build pixi-feedstock with variant win_64_ directly (without setup
 [tasks."inspect-win_64_"]
 cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/win_64_.yaml"
 description = "List contents of pixi-feedstock packages built for variant win_64_"
+[tasks."build-win_arm64_"]
+cmd = "rattler-build build --recipe recipe -m .ci_support/win_arm64_.yaml"
+description = "Build pixi-feedstock with variant win_arm64_ directly (without setup scripts)"
+[tasks."inspect-win_arm64_"]
+cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/win_arm64_.yaml"
+description = "List contents of pixi-feedstock packages built for variant win_arm64_"
 
 [feature.smithy.dependencies]
 conda-smithy = "*"

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -13,7 +13,7 @@ source:
   sha256: b6247d725c8bd859b964a90389cf9e3a4bb01aedb69b002fdae1a305eca86434
 
 build:
-  number: 0
+  number: 1
   script:
     env:
       # This env var  specifies the base 2 log of the allocator page size
@@ -37,7 +37,7 @@ build:
         # This flag is needed for tree-sitter on linux
         $env.CFLAGS = $"($env.CFLAGS) -D_BSD_SOURCE"
       }
-      cargo auditable install --locked --root $env.PREFIX --no-track --path crates/pixi --bin pixi
+      cargo auditable install --locked --no-default-features --features native-tls --root $env.PREFIX --no-track --path crates/pixi --bin pixi
       cargo-bundle-licenses --format yaml --output $"($env.SRC_DIR)/THIRDPARTY.yml"
 
 requirements:
@@ -56,10 +56,10 @@ requirements:
     - if: osx
       then: ld64
   host:
+    # native-tls links openssl on linux (macOS uses Security.framework,
+    # Windows uses schannel, neither needs a host dependency)
     - if: linux
       then: openssl
-    - if: win
-      then: libgit2
 
 tests:
   - script:


### PR DESCRIPTION
## Summary

Enables experimental `win-arm64` builds (cross-compiled from `win-64`) and fixes the overdepending warnings by aligning the recipe with what pixi actually links.

### win-arm64
- Added `win_arm64: win_64` to `build_platform` in `conda-forge.yml` and re-rendered (generates `.ci_support/win_arm64_.yaml`, wires it into the Windows Azure pipeline). `test: native_and_emulated` was already set.

### Build with native-tls instead of rustls
- The package defaults to the `rustls` feature, so `openssl` was declared in `host` but never linked → `Overdepending against openssl`.
- Now builds with `--no-default-features --features native-tls`, so pixi links the platform TLS stack: **openssl on linux** (conda's, via `OPENSSL_DIR`), **Security.framework on macOS**, **schannel on windows**. The `openssl` host dep is kept for linux only.

### Drop the libgit2 host dep
- pixi shells out to the `git` CLI (`pixi_git` / `uv-git`); it links no git library — `git2` / `libgit2-sys` / `gix` are all absent from `Cargo.lock`. This removes the `Overdepending against libgit2` warning and unblocks `win-arm64` (no libgit2 to build for that target).

Build number bumped to 1 (deps/features changed for existing platforms).

## Checklist

- [x] Used a personal fork of the feedstock to propose changes
- [x] Bumped the build number (version unchanged, build config changed)
- [x] Re-rendered with the latest conda-smithy
- [x] Ensured the license file is being packaged
